### PR TITLE
Close tooltip after verifying its content

### DIFF
--- a/src/material-interactions/tooltip.ts
+++ b/src/material-interactions/tooltip.ts
@@ -6,5 +6,7 @@ export class Tooltip {
     for (const text of texts) {
       cy.get('.mat-tooltip').should('contain', text);
     }
+
+    element.trigger('mouseleave');
   }
 }


### PR DESCRIPTION
Angular Material 14 finally relies on mouseleave to close tooltips.