### PR TITLE
Fix dragAndDrop with >=16.2.12 Angular CDK

### DIFF
--- a/src/commands/drag-and-drop.ts
+++ b/src/commands/drag-and-drop.ts
@@ -26,7 +26,7 @@ Cypress.Commands.add('dragAndDrop', { prevSubject: 'element' }, (draggable, drop
       return cy.wrap(draggable);
     })
     .then(([draggable]) => {
-      draggable.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, buttons: 1, composed: true }));
+      draggable.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, buttons: 1, composed: true, detail: 1 }));
 
       draggable.dispatchEvent(
         new MouseEvent('mousemove', {


### PR DESCRIPTION
Angular CDK >=16.2.12 treats mousedown events with detail set to zero as synthetic screen-reader events. MouseEvent defaults detail to zero, so CDK ignores the event dispatched by dragAndDrop and never starts the drag.

MouseEvent.detail is the click count for mouse-button events. For mousedown, it is 1 on the first press, 2 on the second press of a double-click sequence, and so on. A real pointer-generated first mousedown therefore has detail: 1; the constructor default of 0 describes an event with no click count, which is typical of synthetic/accessibility-triggered activation rather than a physical mouse press.

Set detail to one to represent the first physical mouse press, matching the event generated by a browser and Angular CDK's own test event factory.

Upstream: https://github.com/angular/components/commit/737c7a8